### PR TITLE
substitute long_description if README.md is missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,12 @@ except ImportError:
     from distutils.core import setup
 
 
+try:
+    long_description = open('README.md').read()
+except:
+    long_description = u'Street address parser and formatter'
+
+
 CLASSIFIERS=[
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
@@ -21,7 +27,7 @@ setup(
         name='street-address',
         version='0.2.0',
         description='Street address parser and formatter',
-        long_description = open('README.md').read(),
+        long_description=long_description,
         author='PN',
         author_email='pn.appdev@gmail.com',
         url='https://github.com/pnpnpn/street-address',


### PR DESCRIPTION
Version 0.2.0 in PyPI fails running "pip install street-address" with message:

```
    long_description = open('README.md').read(),

IOError: [Errno 2] No such file or directory: 'README.md'
```

README.md is missing from the tarball on PyPI, so this works around in case it is missing.
